### PR TITLE
fix: use latest Deno icon

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -121,6 +121,9 @@ export default defineConfig({
 ``` [bun]
 ```
 
+``` [deno]
+```
+
 :::
 
 ### Frameworks

--- a/src/builtin.ts
+++ b/src/builtin.ts
@@ -4,7 +4,7 @@ export const builtinIcons = {
   'npm': 'vscode-icons:file-type-npm',
   'yarn': 'vscode-icons:file-type-yarn',
   'bun': 'vscode-icons:file-type-bun',
-  'deno': 'vscode-icons:file-type-light-deno',
+  'deno': 'vscode-icons:file-type-deno',
   // frameworks
   'vue': 'vscode-icons:file-type-vue',
   'svelte': 'vscode-icons:file-type-svelte',


### PR DESCRIPTION
Since 'vscode-icons:file-type-light-deno' is marked as the old icon, use the latest icon.