### PR TITLE
feat: add `.mts` and `.cts` extensions to `builtin.ts`

### DIFF
--- a/src/builtin.ts
+++ b/src/builtin.ts
@@ -38,7 +38,7 @@ export const builtinIcons = {
   '.oxlintrc': 'vscode-icons:file-type-oxlint',
   // filename extensions
   '.mts': 'vscode-icons:file-type-typescript',
-  '.cts': 'vscode-icons:file-type-typescript',  
+  '.cts': 'vscode-icons:file-type-typescript',
   '.ts': 'vscode-icons:file-type-typescript',
   '.tsx': 'vscode-icons:file-type-typescript',
   '.mjs': 'vscode-icons:file-type-js',

--- a/src/builtin.ts
+++ b/src/builtin.ts
@@ -37,6 +37,8 @@ export const builtinIcons = {
   'unocss.config': 'vscode-icons:file-type-unocss',
   '.oxlintrc': 'vscode-icons:file-type-oxlint',
   // filename extensions
+  '.mts': 'vscode-icons:file-type-typescript',
+  '.cts': 'vscode-icons:file-type-typescript',  
   '.ts': 'vscode-icons:file-type-typescript',
   '.tsx': 'vscode-icons:file-type-typescript',
   '.mjs': 'vscode-icons:file-type-js',


### PR DESCRIPTION
Hello, 

Thanks for creating this awesome plugin!

I noticed that `.mts` and `.cts` files don’t currently display the correct TypeScript icons. 

It would be great if you could add support for these extensions!

## Rationale

https://www.typescriptlang.org/docs/handbook/modules/reference.html#module-format-detection

![image](https://github.com/user-attachments/assets/9b61b0b5-5219-4436-9150-8997d88ad19d)
