### PR TITLE
feat: add support for php extension

### DIFF
--- a/src/builtin.ts
+++ b/src/builtin.ts
@@ -54,4 +54,5 @@ export const builtinIcons = {
   '.scss': 'vscode-icons:file-type-scss',
   '.yml': 'vscode-icons:file-type-light-yaml',
   '.yaml': 'vscode-icons:file-type-light-yaml',
+  '.php': 'vscode-icons:file-type-php',
 }


### PR DESCRIPTION
Hey 👋,

I really appreciate your plugin!

Currently, I writing a lot of documentation related to PHP and I was wondering if it could be possible to add the PHP filename extension support within your plugin!

Thanks!