### PR TITLE
feat: add qwik icon

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -154,6 +154,9 @@ export default defineConfig({
 ``` [Nuxt]
 ```
 
+``` [Qwik]
+```
+
 :::
 
 ### Bundlers

--- a/src/builtin.ts
+++ b/src/builtin.ts
@@ -14,6 +14,7 @@ export const builtinIcons = {
   'nuxt': 'vscode-icons:file-type-nuxt',
   'solid': 'logos:solidjs-icon',
   'astro': 'vscode-icons:file-type-light-astro',
+  'qwik': 'logos:qwik-icon',
   // bundlers
   'rollup': 'vscode-icons:file-type-rollup',
   'webpack': 'vscode-icons:file-type-webpack',


### PR DESCRIPTION
The Qwik framework is a vite plugin and builds on top of Vite, this PR adds the Qwik icon in the frameworks section.

If there's anything I missed happy to tackle it 🫡 