### PR TITLE
Support Ember

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -157,6 +157,9 @@ export default defineConfig({
 ``` [Qwik]
 ```
 
+``` [Ember]
+```
+
 :::
 
 ### Bundlers
@@ -239,6 +242,9 @@ export default defineConfig({
 ```
 
 ``` [foo.ico]
+```
+
+``` [foo.gjs]
 ```
 
 :::

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@iconify-json/logos": "^1.2.4",
-    "@iconify-json/vscode-icons": "^1.2.23",
+    "@iconify-json/vscode-icons": "^1.2.29",
     "@iconify/utils": "^3.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.2.4
         version: 1.2.5
       '@iconify-json/vscode-icons':
-        specifier: ^1.2.23
-        version: 1.2.24
+        specifier: ^1.2.29
+        version: 1.2.29
       '@iconify/utils':
         specifier: ^3.0.0
         version: 3.0.0
@@ -678,8 +678,8 @@ packages:
   '@iconify-json/simple-icons@1.2.46':
     resolution: {integrity: sha512-MJfKQDhOMQD5Fc8PcTtCdFX0oBf/nKVfp69ScdEKIXW0JXELX5V2Ld45EsjShi8aJ6DNhdDtSDZvKuDnkDiKnw==}
 
-  '@iconify-json/vscode-icons@1.2.24':
-    resolution: {integrity: sha512-iWWsflaDjX8l9JM9m5OrUtC49fuLveoXud7tVobRRyrDpI5ixdM9yfH20dC9R8aW+qpfPFPi6oC3n1noPsp8gA==}
+  '@iconify-json/vscode-icons@1.2.29':
+    resolution: {integrity: sha512-ByqO3YPYs0n7hakQ/ZUXltJQnYibeOv41H1AdciOs7Pmba5/OsKKK1/oOjcBmvXrYuENO+IvIzORYkl6sFXgqA==}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -3511,7 +3511,7 @@ snapshots:
     dependencies:
       '@iconify/types': 2.0.0
 
-  '@iconify-json/vscode-icons@1.2.24':
+  '@iconify-json/vscode-icons@1.2.29':
     dependencies:
       '@iconify/types': 2.0.0
 

--- a/src/builtin.ts
+++ b/src/builtin.ts
@@ -15,6 +15,7 @@ export const builtinIcons = {
   'solid': 'logos:solidjs-icon',
   'astro': 'vscode-icons:file-type-light-astro',
   'qwik': 'logos:qwik-icon',
+  'ember': 'vscode-icons:file-type-ember',
   // bundlers
   'rollup': 'vscode-icons:file-type-rollup',
   'webpack': 'vscode-icons:file-type-webpack',
@@ -57,4 +58,6 @@ export const builtinIcons = {
   '.yml': 'vscode-icons:file-type-light-yaml',
   '.yaml': 'vscode-icons:file-type-light-yaml',
   '.php': 'vscode-icons:file-type-php',
+  '.gjs': 'vscode-icons:file-type-glimmer',
+  '.gts': 'vscode-icons:file-type-glimmer',
 }


### PR DESCRIPTION
Heyo,

we would love to see Ember being supported here, as more and more projects using vitepress for their documentation.

I updated Ember icons in vscode-icons/vscode-icons#3785 which have been released and picked up by iconify. I now can finally open this PR.

Thank you
gossi