### PR TITLE
chore: move pnpm config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-ignore-workspace-root-check=true
-shell-emulator=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,6 @@ onlyBuiltDependencies:
   - esbuild
   - rolldown
   - simple-git-hooks
+
+ignoreWorkspaceRootCheck: true
+shellEmulator: true


### PR DESCRIPTION
To ease management and avoid conflicts with npm, pnpm supports moving all configurations to the pnpm-workspace.yaml file. For more https://github.com/orgs/pnpm/discussions/9037