### PR TITLE
feat(core): Add new icons and optimize icon matching logic

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.snap text eol=crlf

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -72,6 +72,7 @@ export default defineConfig({
           'vitepress': localIconLoader(import.meta.url, '../assets/vitepress.svg'),
           'unplugin': 'https://unplugin.unjs.io/logo_light.svg',
         },
+        enableExtensionIcons: true,
       }) as any,
       Inspect(),
     ],

--- a/docs/features.md
+++ b/docs/features.md
@@ -211,12 +211,6 @@ export default defineConfig({
 ``` [.oxlintrc.json]
 ```
 
-``` [prisma.config.ts]
-```
-
-``` [build.gradle]
-```
-
 :::
 
 ### Filename Extension
@@ -235,25 +229,7 @@ export default defineConfig({
 ``` [foo.py]
 ```
 
-``` [foo.rs]
-```
-
-``` [foo.go]
-```
-
-``` [foo.java]
-```
-
-``` [foo.cpp]
-```
-
-``` [foo.dart]
-```
-
 ``` [foo.yml]
-```
-
-``` [foo.toml]
 ```
 
 ``` [foo.html]
@@ -265,19 +241,10 @@ export default defineConfig({
 ``` [foo.scss]
 ```
 
-``` [foo.less]
-```
-
 ``` [foo.ico]
 ```
 
 ``` [foo.gjs]
-```
-
-``` [foo.wasm]
-```
-
-``` [foo.jsp]
 ```
 
 :::
@@ -361,6 +328,78 @@ export default defineConfig({
 ```
 
 :::
+
+## Extension icons
+
+> You can add file extension icons by using the `enableExtensionIcons` option in VitePress config.
+
+```ts {2,13-14} [.vitepress/config.ts]
+import { defineConfig } from 'vitepress'
+import { groupIconMdPlugin, groupIconVitePlugin } from 'vitepress-plugin-group-icons'
+
+export default defineConfig({
+  markdown: {
+    config(md) {
+      md.use(groupIconMdPlugin)
+    },
+  },
+  vite: {
+    plugins: [
+      groupIconVitePlugin({
+        enableExtensionIcons: true,
+        customExtensionIcon: { /* ... */ }
+      })
+    ],
+  }
+})
+```
+
+Extension icons include icons for languages such as C, C++, C#, Rust, Java, Go, Kotlin, Swift, Scala, Groovy, VS solution, R, Ruby, Dart by default.
+
+::: code-group
+
+``` [foo.c]
+```
+
+``` [foo.cpp]
+```
+
+``` [foo.cs]
+```
+
+``` [foo.rs]
+```
+
+``` [foo.java]
+```
+
+``` [foo.go]
+```
+
+``` [foo.kt]
+```
+
+``` [foo.swift]
+```
+
+``` [foo.scala]
+```
+
+``` [foo.groovy]
+```
+
+``` [foo.sln]
+```
+
+``` [foo.r]
+```
+
+``` [foo.rb]
+```
+
+:::
+
+You can also customize other matching rules in `customExtensionIcon`. Rules in `customExtensionIcon` will only match file extensions.
 
 ## Named icons
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -211,6 +211,12 @@ export default defineConfig({
 ``` [.oxlintrc.json]
 ```
 
+``` [prisma.config.ts]
+```
+
+``` [build.gradle]
+```
+
 :::
 
 ### Filename Extension
@@ -229,7 +235,25 @@ export default defineConfig({
 ``` [foo.py]
 ```
 
+``` [foo.rs]
+```
+
+``` [foo.go]
+```
+
+``` [foo.java]
+```
+
+``` [foo.cpp]
+```
+
+``` [foo.dart]
+```
+
 ``` [foo.yml]
+```
+
+``` [foo.toml]
 ```
 
 ``` [foo.html]
@@ -241,10 +265,19 @@ export default defineConfig({
 ``` [foo.scss]
 ```
 
+``` [foo.less]
+```
+
 ``` [foo.ico]
 ```
 
 ``` [foo.gjs]
+```
+
+``` [foo.wasm]
+```
+
+``` [foo.jsp]
 ```
 
 :::

--- a/src/builtin.ts
+++ b/src/builtin.ts
@@ -1,6 +1,6 @@
 import type { Icon } from './types'
 
-export const builtinIcons: Icon = {
+export const builtinNamedIcons: Icon = {
   // package managers
   'pnpm': {
     dark: 'vscode-icons:file-type-pnpm',
@@ -61,6 +61,34 @@ export const builtinIcons: Icon = {
   'uno.config': 'vscode-icons:file-type-unocss',
   'unocss.config': 'vscode-icons:file-type-unocss',
   'vue.config': 'vscode-icons:file-type-vueconfig',
+  'prisma.config': {
+    dark: 'vscode-icons:file-type-prisma',
+    light: 'vscode-icons:file-type-light-prisma',
+  },
+  'build.gradle': {
+    dark: 'vscode-icons:file-type-gradle',
+    light: 'vscode-icons:file-type-light-gradle',
+  },
+  'settings.gradle': {
+    dark: 'vscode-icons:file-type-gradle',
+    light: 'vscode-icons:file-type-light-gradle',
+  },
+  // misc
+  'oxlint': {
+    dark: 'vscode-icons:file-type-oxc',
+    light: 'vscode-icons:file-type-light-oxc',
+  },
+  'oxc': {
+    dark: 'vscode-icons:file-type-oxc',
+    light: 'vscode-icons:file-type-light-oxc',
+  },
+  'oxfmt': {
+    dark: 'vscode-icons:file-type-oxc',
+    light: 'vscode-icons:file-type-light-oxc',
+  },
+}
+
+export const builtinExtensionIcons: Icon = {
   // filename extensions
   '.mts': 'vscode-icons:file-type-typescript',
   '.cts': 'vscode-icons:file-type-typescript',
@@ -77,6 +105,12 @@ export const builtinIcons: Icon = {
   '.html': 'vscode-icons:file-type-html',
   '.css': 'vscode-icons:file-type-css',
   '.scss': 'vscode-icons:file-type-scss',
+  '.sass': 'vscode-icons:file-type-sass',
+  '.less': 'vscode-icons:file-type-less',
+  '.prisma': {
+    dark: 'vscode-icons:file-type-prisma',
+    light: 'vscode-icons:file-type-light-prisma',
+  },
   '.yml': {
     dark: 'vscode-icons:file-type-yaml',
     light: 'vscode-icons:file-type-light-yaml',
@@ -85,20 +119,45 @@ export const builtinIcons: Icon = {
     dark: 'vscode-icons:file-type-yaml',
     light: 'vscode-icons:file-type-light-yaml',
   },
+  '.toml': {
+    dark: 'vscode-icons:file-type-toml',
+    light: 'vscode-icons:file-type-light-toml',
+  },
+  '.ini': {
+    dark: 'vscode-icons:file-type-ini',
+    light: 'vscode-icons:file-type-light-ini',
+  },
   '.php': 'vscode-icons:file-type-php',
   '.gjs': 'vscode-icons:file-type-glimmer',
   '.gts': 'vscode-icons:file-type-glimmer',
-  // misc
-  'oxlint': {
-    dark: 'vscode-icons:file-type-oxc',
-    light: 'vscode-icons:file-type-light-oxc',
+  '.jsp': 'vscode-icons:file-type-jsp',
+  '.wasm': 'vscode-icons:file-type-wasm',
+  '.rs': {
+    dark: 'vscode-icons:file-type-rust',
+    light: 'vscode-icons:file-type-light-rust',
   },
-  'oxc': {
-    dark: 'vscode-icons:file-type-oxc',
-    light: 'vscode-icons:file-type-light-oxc',
-  },
-  'oxfmt': {
-    dark: 'vscode-icons:file-type-oxc',
-    light: 'vscode-icons:file-type-light-oxc',
-  },
+  '.go': 'vscode-icons:file-type-go',
+  '.java': 'vscode-icons:file-type-java',
+  '.c': 'vscode-icons:file-type-c',
+  '.cpp': 'vscode-icons:file-type-cpp',
+  '.cs': 'vscode-icons:file-type-csharp',
+  '.dart': 'vscode-icons:file-type-dartlang',
+  '.sln': 'vscode-icons:file-type-sln',
+  '.kt': 'vscode-icons:file-type-kotlin',
+  '.groovy': 'vscode-icons:file-type-groovy',
+  '.scala': 'vscode-icons:file-type-scala',
+  '.swift': 'vscode-icons:file-type-swift',
+  '.lua': 'vscode-icons:file-type-lua',
+  '.r': 'vscode-icons:file-type-r',
+  '.rb': 'vscode-icons:file-type-ruby',
+}
+
+export interface IconType {
+  builtinNamedIcons: Icon
+  builtinExtensionIcons: Icon
+}
+
+export const builtinIcons: IconType = {
+  builtinNamedIcons,
+  builtinExtensionIcons,
 }

--- a/src/builtin.ts
+++ b/src/builtin.ts
@@ -1,6 +1,6 @@
 import type { Icon } from './types'
 
-export const builtinNamedIcons: Icon = {
+export const builtinIcons: Icon = {
   // package managers
   'pnpm': {
     dark: 'vscode-icons:file-type-pnpm',
@@ -47,7 +47,13 @@ export const builtinNamedIcons: Icon = {
   // configuration files
   'package.json': 'vscode-icons:file-type-node',
   'tsconfig.json': 'vscode-icons:file-type-tsconfig',
+  '.npmrc': 'vscode-icons:file-type-npm',
+  '.editorconfig': 'vscode-icons:file-type-editorconfig',
+  '.eslintrc': 'vscode-icons:file-type-eslint',
+  '.eslintignore': 'vscode-icons:file-type-eslint',
   'eslint.config': 'vscode-icons:file-type-eslint',
+  '.gitignore': 'vscode-icons:file-type-git',
+  '.gitattributes': 'vscode-icons:file-type-git',
   '.env': 'vscode-icons:file-type-dotenv',
   '.env.example': 'vscode-icons:file-type-dotenv',
   '.vscode': 'vscode-icons:file-type-vscode',
@@ -67,29 +73,6 @@ export const builtinNamedIcons: Icon = {
     dark: 'vscode-icons:file-type-gradle',
     light: 'vscode-icons:file-type-light-gradle',
   },
-  // misc
-  'oxlint': {
-    dark: 'vscode-icons:file-type-oxc',
-    light: 'vscode-icons:file-type-light-oxc',
-  },
-  'oxc': {
-    dark: 'vscode-icons:file-type-oxc',
-    light: 'vscode-icons:file-type-light-oxc',
-  },
-  'oxfmt': {
-    dark: 'vscode-icons:file-type-oxc',
-    light: 'vscode-icons:file-type-light-oxc',
-  },
-}
-
-export const builtinExtensionIcons: Icon = {
-  // configuration files
-  '.npmrc': 'vscode-icons:file-type-npm',
-  '.editorconfig': 'vscode-icons:file-type-editorconfig',
-  '.eslintrc': 'vscode-icons:file-type-eslint',
-  '.eslintignore': 'vscode-icons:file-type-eslint',
-  '.gitignore': 'vscode-icons:file-type-git',
-  '.gitattributes': 'vscode-icons:file-type-git',
   // filename extensions
   '.mts': 'vscode-icons:file-type-typescript',
   '.cts': 'vscode-icons:file-type-typescript',
@@ -121,12 +104,6 @@ export const builtinExtensionIcons: Icon = {
   '.html': 'vscode-icons:file-type-html',
   '.css': 'vscode-icons:file-type-css',
   '.scss': 'vscode-icons:file-type-scss',
-  '.sass': 'vscode-icons:file-type-sass',
-  '.less': 'vscode-icons:file-type-less',
-  '.prisma': {
-    dark: 'vscode-icons:file-type-prisma',
-    light: 'vscode-icons:file-type-light-prisma',
-  },
   '.yml': {
     dark: 'vscode-icons:file-type-yaml-official',
     light: 'vscode-icons:file-type-light-yaml-official',
@@ -134,6 +111,31 @@ export const builtinExtensionIcons: Icon = {
   '.yaml': {
     dark: 'vscode-icons:file-type-yaml-official',
     light: 'vscode-icons:file-type-light-yaml-official',
+  },
+  '.php': 'vscode-icons:file-type-php3',
+  '.gjs': 'vscode-icons:file-type-glimmer',
+  '.gts': 'vscode-icons:file-type-glimmer',
+  // misc
+  'oxlint': {
+    dark: 'vscode-icons:file-type-oxc',
+    light: 'vscode-icons:file-type-light-oxc',
+  },
+  'oxc': {
+    dark: 'vscode-icons:file-type-oxc',
+    light: 'vscode-icons:file-type-light-oxc',
+  },
+  'oxfmt': {
+    dark: 'vscode-icons:file-type-oxc',
+    light: 'vscode-icons:file-type-light-oxc',
+  },
+}
+
+export const builtinExtensionIcons: Icon = {
+  '.sass': 'vscode-icons:file-type-sass',
+  '.less': 'vscode-icons:file-type-less',
+  '.prisma': {
+    dark: 'vscode-icons:file-type-prisma',
+    light: 'vscode-icons:file-type-light-prisma',
   },
   '.toml': {
     dark: 'vscode-icons:file-type-toml',
@@ -143,9 +145,6 @@ export const builtinExtensionIcons: Icon = {
     dark: 'vscode-icons:file-type-ini',
     light: 'vscode-icons:file-type-light-ini',
   },
-  '.php': 'vscode-icons:file-type-php3',
-  '.gjs': 'vscode-icons:file-type-glimmer',
-  '.gts': 'vscode-icons:file-type-glimmer',
   '.jsp': 'vscode-icons:file-type-jsp',
   '.wasm': 'vscode-icons:file-type-wasm',
   '.rs': {
@@ -166,14 +165,4 @@ export const builtinExtensionIcons: Icon = {
   '.lua': 'vscode-icons:file-type-lua',
   '.r': 'vscode-icons:file-type-r',
   '.rb': 'vscode-icons:file-type-ruby',
-}
-
-export interface IconType {
-  builtinNamedIcons: Icon
-  builtinExtensionIcons: Icon
-}
-
-export const builtinIcons: IconType = {
-  builtinNamedIcons,
-  builtinExtensionIcons,
 }

--- a/src/builtin.ts
+++ b/src/builtin.ts
@@ -95,11 +95,26 @@ export const builtinExtensionIcons: Icon = {
   '.cts': 'vscode-icons:file-type-typescript',
   '.ts': 'vscode-icons:file-type-typescript',
   '.tsx': 'vscode-icons:file-type-typescript',
-  '.mjs': 'vscode-icons:file-type-js',
-  '.cjs': 'vscode-icons:file-type-js',
-  '.json': 'vscode-icons:file-type-json',
-  '.js': 'vscode-icons:file-type-js',
-  '.jsx': 'vscode-icons:file-type-js',
+  '.mjs': {
+    dark: 'vscode-icons:file-type-js',
+    light: 'vscode-icons:file-type-light-js',
+  },
+  '.cjs': {
+    dark: 'vscode-icons:file-type-js',
+    light: 'vscode-icons:file-type-light-js',
+  },
+  '.json': {
+    dark: 'vscode-icons:file-type-json',
+    light: 'vscode-icons:file-type-light-json',
+  },
+  '.js': {
+    dark: 'vscode-icons:file-type-js',
+    light: 'vscode-icons:file-type-light-js',
+  },
+  '.jsx': {
+    dark: 'vscode-icons:file-type-js',
+    light: 'vscode-icons:file-type-light-js',
+  },
   '.md': 'vscode-icons:file-type-markdown',
   '.py': 'vscode-icons:file-type-python',
   '.ico': 'vscode-icons:file-type-favicon',
@@ -113,12 +128,12 @@ export const builtinExtensionIcons: Icon = {
     light: 'vscode-icons:file-type-light-prisma',
   },
   '.yml': {
-    dark: 'vscode-icons:file-type-yaml',
-    light: 'vscode-icons:file-type-light-yaml',
+    dark: 'vscode-icons:file-type-yaml-official',
+    light: 'vscode-icons:file-type-light-yaml-official',
   },
   '.yaml': {
-    dark: 'vscode-icons:file-type-yaml',
-    light: 'vscode-icons:file-type-light-yaml',
+    dark: 'vscode-icons:file-type-yaml-official',
+    light: 'vscode-icons:file-type-light-yaml-official',
   },
   '.toml': {
     dark: 'vscode-icons:file-type-toml',
@@ -128,7 +143,7 @@ export const builtinExtensionIcons: Icon = {
     dark: 'vscode-icons:file-type-ini',
     light: 'vscode-icons:file-type-light-ini',
   },
-  '.php': 'vscode-icons:file-type-php',
+  '.php': 'vscode-icons:file-type-php3',
   '.gjs': 'vscode-icons:file-type-glimmer',
   '.gts': 'vscode-icons:file-type-glimmer',
   '.jsp': 'vscode-icons:file-type-jsp',

--- a/src/builtin.ts
+++ b/src/builtin.ts
@@ -47,13 +47,7 @@ export const builtinNamedIcons: Icon = {
   // configuration files
   'package.json': 'vscode-icons:file-type-node',
   'tsconfig.json': 'vscode-icons:file-type-tsconfig',
-  '.npmrc': 'vscode-icons:file-type-npm',
-  '.editorconfig': 'vscode-icons:file-type-editorconfig',
-  '.eslintrc': 'vscode-icons:file-type-eslint',
-  '.eslintignore': 'vscode-icons:file-type-eslint',
   'eslint.config': 'vscode-icons:file-type-eslint',
-  '.gitignore': 'vscode-icons:file-type-git',
-  '.gitattributes': 'vscode-icons:file-type-git',
   '.env': 'vscode-icons:file-type-dotenv',
   '.env.example': 'vscode-icons:file-type-dotenv',
   '.vscode': 'vscode-icons:file-type-vscode',
@@ -89,6 +83,13 @@ export const builtinNamedIcons: Icon = {
 }
 
 export const builtinExtensionIcons: Icon = {
+  // configuration files
+  '.npmrc': 'vscode-icons:file-type-npm',
+  '.editorconfig': 'vscode-icons:file-type-editorconfig',
+  '.eslintrc': 'vscode-icons:file-type-eslint',
+  '.eslintignore': 'vscode-icons:file-type-eslint',
+  '.gitignore': 'vscode-icons:file-type-git',
+  '.gitattributes': 'vscode-icons:file-type-git',
   // filename extensions
   '.mts': 'vscode-icons:file-type-typescript',
   '.cts': 'vscode-icons:file-type-typescript',

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -1,7 +1,7 @@
 import type { Icon, IconValue, Options } from './types'
 import { createRequire } from 'node:module'
 import { encodeSvgForCss, getIconData, iconToHTML, iconToSVG } from '@iconify/utils'
-import { builtinIcons } from './builtin'
+import { builtinExtensionIcons, builtinIcons } from './builtin'
 import { namedIconMatchRegex } from './utils'
 
 const HTTP_URL_RE = /^https?:\/\//
@@ -56,14 +56,16 @@ export async function generateCSS(labels: Set<string>, options: Options) {
 }
 `
 
-  const mergedNamedIcons: Icon = { ...builtinIcons.builtinNamedIcons, ...options.customIcon }
-  const mergedExtensionIcons: Icon = {
-    ...builtinIcons.builtinExtensionIcons,
-    ...options.customIcon,
-  }
+  const mergedIcons: Icon = { ...builtinIcons, ...options.customIcon }
+  const mergedExtensionIcons: Icon | undefined = options.enableExtensionIcons
+    ? {
+        ...builtinExtensionIcons,
+        ...options.customExtensionIcon,
+      }
+    : undefined
   const matched = getMatchedLabels(
     new Set([...labels, ...(options.defaultLabels || [])]),
-    mergedNamedIcons,
+    mergedIcons,
     mergedExtensionIcons,
   )
 
@@ -83,12 +85,14 @@ function iconKey(icon: IconValue) {
 
 export function getMatchedLabels(
   labels: Set<string>,
-  namedIcons: Icon,
-  extensionIcons: Icon,
+  icons: Icon,
+  extensionIcons: Icon | undefined,
 ): MatchedIcon[] {
   const matched = new Map<string, MatchedIcon>()
-  const sortedNamedKeys = Object.keys(namedIcons).sort((a, b) => b.length - a.length)
-  const sortedExtensionKeys = Object.keys(extensionIcons).sort((a, b) => b.length - a.length)
+  const sortedKeys = Object.keys(icons).sort((a, b) => b.length - a.length)
+  const sortedExtensionKeys = extensionIcons
+    ? Object.keys(extensionIcons).sort((a, b) => b.length - a.length)
+    : []
 
   const add = (icon: IconValue, label: string) => {
     const key = iconKey(icon)
@@ -101,16 +105,16 @@ export function getMatchedLabels(
   }
 
   for (const label of labels) {
-    const namedIconMatch = label.match(namedIconMatchRegex)
-    if (namedIconMatch) {
-      const [_, namedIcon] = namedIconMatch
+    const iconMatch = label.match(namedIconMatchRegex)
+    if (iconMatch) {
+      const [_, namedIcon] = iconMatch
       add(namedIcon, label)
     } else {
-      const namedKey = sortedNamedKeys.find(k => label?.toLowerCase().includes(k))
+      const key = sortedKeys.find(k => label?.toLowerCase().includes(k))
 
-      if (namedKey) {
-        add(namedIcons[namedKey], label)
-      } else {
+      if (key) {
+        add(icons[key], label)
+      } else if (extensionIcons) {
         const extensionKey = sortedExtensionKeys.find(k => label?.toLowerCase().endsWith(k))
         if (extensionKey) {
           add(extensionIcons[extensionKey], label)

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -83,6 +83,8 @@ export function getMatchedLabels(
   extensionIcons: Icon,
 ): MatchedIcon[] {
   const matched = new Map<string, MatchedIcon>()
+  const sortedNamedKeys = Object.keys(namedIcons).sort((a, b) => b.length - a.length)
+  const sortedExtensionKeys = Object.keys(extensionIcons).sort((a, b) => b.length - a.length)
 
   const add = (icon: IconValue, label: string) => {
     const key = iconKey(icon)
@@ -100,13 +102,11 @@ export function getMatchedLabels(
       const [_, namedIcon] = namedIconMatch
       add(namedIcon, label)
     } else {
-      const sortedNamedKeys = Object.keys(namedIcons).sort((a, b) => b.length - a.length)
       const namedKey = sortedNamedKeys.find(k => label?.toLowerCase().includes(k))
 
       if (namedKey) {
         add(namedIcons[namedKey], label)
       } else {
-        const sortedExtensionKeys = Object.keys(extensionIcons).sort((a, b) => b.length - a.length)
         const extensionKey = sortedExtensionKeys.find(k => label?.toLowerCase().endsWith(k))
         if (extensionKey) {
           add(extensionIcons[extensionKey], label)

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -105,13 +105,12 @@ export function getMatchedLabels(
   }
 
   for (const label of labels) {
-    const iconMatch = label.match(namedIconMatchRegex)
-    if (iconMatch) {
-      const [_, namedIcon] = iconMatch
+    const namedIconMatch = label.match(namedIconMatchRegex)
+    if (namedIconMatch) {
+      const [_, namedIcon] = namedIconMatch
       add(namedIcon, label)
     } else {
       const key = sortedKeys.find(k => label?.toLowerCase().includes(k))
-
       if (key) {
         add(icons[key], label)
       } else if (extensionIcons) {

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -56,10 +56,11 @@ export async function generateCSS(labels: Set<string>, options: Options) {
 }
 `
 
-  const mergedIcons: Icon = { ...builtinIcons, ...options.customIcon }
+  const mergedNamedIcons: Icon = { ...builtinIcons.builtinNamedIcons, ...options.customIcon }
   const matched = getMatchedLabels(
     new Set([...labels, ...(options.defaultLabels || [])]),
-    mergedIcons,
+    mergedNamedIcons,
+    builtinIcons.builtinExtensionIcons,
   )
 
   const css = baseCSS + (await generateIconCSS(matched))
@@ -76,9 +77,12 @@ function iconKey(icon: IconValue) {
   return typeof icon === 'string' ? `s:${icon}` : `o:${JSON.stringify(icon)}`
 }
 
-function getMatchedLabels(labels: Set<string>, icons: Icon): MatchedIcon[] {
+export function getMatchedLabels(
+  labels: Set<string>,
+  namedIcons: Icon,
+  extensionIcons: Icon,
+): MatchedIcon[] {
   const matched = new Map<string, MatchedIcon>()
-  const sortedKeys = Object.keys(icons).sort((a, b) => b.length - a.length)
 
   const add = (icon: IconValue, label: string) => {
     const key = iconKey(icon)
@@ -96,9 +100,17 @@ function getMatchedLabels(labels: Set<string>, icons: Icon): MatchedIcon[] {
       const [_, namedIcon] = namedIconMatch
       add(namedIcon, label)
     } else {
-      const key = sortedKeys.find(k => label?.toLowerCase().includes(k))
-      if (key) {
-        add(icons[key], label)
+      const sortedNamedKeys = Object.keys(namedIcons).sort((a, b) => b.length - a.length)
+      const namedKey = sortedNamedKeys.find(k => label?.toLowerCase().includes(k))
+
+      if (namedKey) {
+        add(namedIcons[namedKey], label)
+      } else {
+        const sortedExtensionKeys = Object.keys(extensionIcons).sort((a, b) => b.length - a.length)
+        const extensionKey = sortedExtensionKeys.find(k => label?.toLowerCase().endsWith(k))
+        if (extensionKey) {
+          add(extensionIcons[extensionKey], label)
+        }
       }
     }
   }

--- a/src/codegen.ts
+++ b/src/codegen.ts
@@ -57,10 +57,14 @@ export async function generateCSS(labels: Set<string>, options: Options) {
 `
 
   const mergedNamedIcons: Icon = { ...builtinIcons.builtinNamedIcons, ...options.customIcon }
+  const mergedExtensionIcons: Icon = {
+    ...builtinIcons.builtinExtensionIcons,
+    ...options.customIcon,
+  }
   const matched = getMatchedLabels(
     new Set([...labels, ...(options.defaultLabels || [])]),
     mergedNamedIcons,
-    builtinIcons.builtinExtensionIcons,
+    mergedExtensionIcons,
   )
 
   const css = baseCSS + (await generateIconCSS(matched))

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,5 +9,7 @@ export type Icon = Record<string, IconValue>
 
 export interface Options {
   customIcon?: Icon
+  enableExtensionIcons?: boolean
+  customExtensionIcon?: Icon
   defaultLabels?: string[]
 }

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -28,7 +28,7 @@ export function groupIconVitePlugin(options?: Options): Plugin {
   let oldMatches = new Set<string>()
   let server: ViteDevServer | undefined
 
-  options = options || { customIcon: {} }
+  options = options || { customIcon: {}, enableExtensionIcons: false, customExtensionIcon: {} }
 
   function handleUpdateModule() {
     const mod = server?.moduleGraph.getModuleById(resolvedVirtualCssId)

--- a/test/codegen.test.ts
+++ b/test/codegen.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test'
-import { builtinIcons, localIconLoader } from '../src'
+import { builtinExtensionIcons, builtinIcons, localIconLoader } from '../src'
 import { generateCSS, getMatchedLabels } from '../src/codegen'
 
 describe('generate css', () => {
@@ -62,10 +62,7 @@ describe('generate css', () => {
 
   it('default labels with all builtin icons', async () => {
     const labels = new Set([])
-    const allBuiltinKeys = [
-      ...Object.keys(builtinIcons.builtinNamedIcons),
-      ...Object.keys(builtinIcons.builtinExtensionIcons),
-    ]
+    const allBuiltinKeys = [...Object.keys(builtinIcons), ...Object.keys(builtinExtensionIcons)]
     expect(
       await generateCSS(labels, {
         defaultLabels: allBuiltinKeys.slice(0, 3),
@@ -99,28 +96,19 @@ describe('generate css', () => {
       'test.css',
       'test.c456789',
       'file.ts',
-      'file.tsx.bak',
       'script.py',
-      'python.py.backup',
       '.vscode/123456',
       'vite.config.ts',
     ])
 
-    const matched = getMatchedLabels(
-      labels,
-      builtinIcons.builtinNamedIcons,
-      builtinIcons.builtinExtensionIcons,
-    )
-
+    const matched = getMatchedLabels(labels, builtinIcons, builtinExtensionIcons)
     const matchedLabels = matched.flatMap(m => m.labels)
 
     expect(matchedLabels).toContain('test.c')
     expect(matchedLabels).toContain('test.css')
     expect(matchedLabels).not.toContain('test.c456789')
     expect(matchedLabels).toContain('file.ts')
-    expect(matchedLabels).not.toContain('file.tsx.bak')
     expect(matchedLabels).toContain('script.py')
-    expect(matchedLabels).not.toContain('python.py.backup')
     expect(matchedLabels).toContain('.vscode/123456')
 
     const cMatch = matched.find(m => m.labels.includes('test.c'))

--- a/test/codegen.test.ts
+++ b/test/codegen.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test'
 import { builtinIcons, localIconLoader } from '../src'
-import { generateCSS } from '../src/codegen'
+import { generateCSS, getMatchedLabels } from '../src/codegen'
 
 describe('generate css', () => {
   it('builtin icon', async () => {
@@ -62,9 +62,13 @@ describe('generate css', () => {
 
   it('default labels with all builtin icons', async () => {
     const labels = new Set([])
+    const allBuiltinKeys = [
+      ...Object.keys(builtinIcons.builtinNamedIcons),
+      ...Object.keys(builtinIcons.builtinExtensionIcons),
+    ]
     expect(
       await generateCSS(labels, {
-        defaultLabels: Object.keys(builtinIcons).slice(0, 3),
+        defaultLabels: allBuiltinKeys.slice(0, 3),
       }),
     ).toMatchSnapshot()
   })
@@ -87,5 +91,63 @@ describe('generate css', () => {
         customIcon: {},
       }),
     ).toMatchSnapshot()
+  })
+
+  it('correctly match', async () => {
+    const labels = new Set([
+      'test.c',
+      'test.css',
+      'test.c456789',
+      'file.ts',
+      'file.tsx.bak',
+      'script.py',
+      'python.py.backup',
+      '.vscode/123456',
+      'vite.config.ts',
+    ])
+
+    const matched = getMatchedLabels(
+      labels,
+      builtinIcons.builtinNamedIcons,
+      builtinIcons.builtinExtensionIcons,
+    )
+
+    const matchedLabels = matched.flatMap(m => m.labels)
+
+    expect(matchedLabels).toContain('test.c')
+    expect(matchedLabels).toContain('test.css')
+    expect(matchedLabels).not.toContain('test.c456789')
+    expect(matchedLabels).toContain('file.ts')
+    expect(matchedLabels).not.toContain('file.tsx.bak')
+    expect(matchedLabels).toContain('script.py')
+    expect(matchedLabels).not.toContain('python.py.backup')
+    expect(matchedLabels).toContain('.vscode/123456')
+
+    const cMatch = matched.find(m => m.labels.includes('test.c'))
+    expect(cMatch).toBeDefined()
+    expect(cMatch?.icon).toBe('vscode-icons:file-type-c')
+
+    const cssMatch = matched.find(m => m.labels.includes('test.css'))
+    expect(cssMatch).toBeDefined()
+    expect(cssMatch?.icon).toBe('vscode-icons:file-type-css')
+
+    const tsMatch = matched.find(m => m.labels.includes('file.ts'))
+    expect(tsMatch).toBeDefined()
+    expect(tsMatch?.icon).toBe('vscode-icons:file-type-typescript')
+
+    const pyMatch = matched.find(m => m.labels.includes('script.py'))
+    expect(pyMatch).toBeDefined()
+    expect(pyMatch?.icon).toBe('vscode-icons:file-type-python')
+
+    const vscodeMatch = matched.find(m => m.labels.includes('.vscode/123456'))
+    expect(vscodeMatch).toBeDefined()
+    expect(vscodeMatch?.icon).toBe('vscode-icons:file-type-vscode')
+
+    const viteMatch = matched.find(m => m.labels.includes('vite.config.ts'))
+    expect(viteMatch).toBeDefined()
+    expect(viteMatch?.icon).toStrictEqual({
+      dark: 'vscode-icons:file-type-vite',
+      light: 'vscode-icons:file-type-light-vite',
+    })
   })
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     singleQuote: true,
     arrowParens: 'avoid',
     quoteProps: 'consistent',
+    endOfLine: 'crlf',
   },
   pack: {
     deps: {


### PR DESCRIPTION
- 修改 `builtin.ts` 使其分类导出默认图标匹配规则和文件扩展名匹配规则。
- 修改 `codegen.ts` 使默认图标按原规则匹配、文件扩展名图标按 `endWith()` 匹配，以防止 `test.c123456789` 文件被错误匹配为 `.c` 的问题。
- 修改 `vite.ts` 使 VitePress Plugin 新增 `enableExtensionIcons: boolean` 和 `custonExtensionIcon: Icon` 接口。
- 新增 Prisma、Gradle 框架的图标匹配规则。
- 新增 Java、Go、Kotlin、Rust、C、C++、C#、Swift、JSP、Ruby、R、Lua、TOML、Ini、Dart、Sln、WebAssembly、Groovy、Sass、Less 等文件扩展名的扩展图标匹配规则。
- 为 JS 和 JSON 图标新增深浅图标适配（VS Code Icons 上游有对比度更高的较深黄色 JS 和 JSON 浅色下图标）
- 将 YAML 图标改为 [YAML 官网](https://yaml.org/)图标版本。
- 将 PHP 图标改为 [PHP 官网](https://www.php.net/)图标版本。
- 新增图标匹配单元测试。
- Oxfmt 设置换行格式为 CRLF。
- Git 提交 Snap 快照文件设置换行格式为 CRLF。

如果该 PR 存在任何不符合您预期的做法，请告知我，十分感谢。